### PR TITLE
Fix: Respects that Leaf can become a Parent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,11 @@ function wrapNode(node, parent) {
     set: setParent
   })
 
-  if (node.children) {
-    Object.defineProperty(proxy, 'children', {
-      enumerable: true,
-      configurable: true,
-      get: getChildren
-    })
-  }
+  Object.defineProperty(proxy, 'children', {
+    enumerable: true,
+    configurable: true,
+    get: getChildren
+  })
 
   cache.set(node, proxy)
 
@@ -60,7 +58,7 @@ function wrapNode(node, parent) {
   }
 
   function getChildren() {
-    return node.children.map(wrap)
+    return node.children && node.children.map(wrap)
   }
 
   function wrap(child) {


### PR DESCRIPTION
I ran into this issue when I was creating a tree of checkboxes. A checkbox can be a Leaf but can become a Parent (represents the whole category). In case a new checkbox is assigned to the existing one, I create a `children` array on the existing one, and put the new one there. That's how Leaf turns into a Parent.

The issue is - I'm not able to access the children of the wrapped Node (Leaf that became Parent) because it was cached without children. This PR illustrates a solution, where the decision - whether the `children` exist - is moved to the point when they are demanded. However, there is a drawback - `enumerable` is fixed on `true`. I believe in the wrapped tree that is not a big deal.

Cheers!